### PR TITLE
Example: Access Django's render context in TypeScript

### DIFF
--- a/scrub_hub_project/scrub_hub_frontend/templates/scrub_hub_frontend/index.html
+++ b/scrub_hub_project/scrub_hub_frontend/templates/scrub_hub_frontend/index.html
@@ -5,6 +5,14 @@
 	<!-- hot reload support -->
 	{% vite_hmr_client %}
 	{% vite_react_refresh %}
+	<!--
+		We use a Django template filter to get the context data.
+		The json_script filter creates a script tag with type="application/json".
+		The contents are a Python object from Django's render context (in this case, "data")
+		The ID of the script tag is "_DjangoData_", making it's contents accessible via document.getElementById.
+		There's a helper method in scrub_hub_vite/src/GetScriptData.ts
+	-->
+	{{ data|json_script:"_DjangoData_" }}
 </head>
 <body>
 	<div id="root"></div>

--- a/scrub_hub_project/scrub_hub_frontend/views.py
+++ b/scrub_hub_project/scrub_hub_frontend/views.py
@@ -1,14 +1,12 @@
 from django.shortcuts import render
 
 def index(request):
-	return render(request, 'scrub_hub_frontend/index.html')
-
-
-def send_simple_message():
-	return requests.post(
-		"https://api.mailgun.net/v3/sandbox8b286874e61244339fc3acedffa31c50/messages",
-		auth=("api", "4b670513-2c867c8b"),
-		data={"from": "Excited User <consolecowboytest@gmail.com>",
-			"to": ["bar@example.com", "swordgeo1094@yahoo.com"],
-			"subject": "Hello",
-			"text": "Testing some Mailgun awesomeness!"})
+	objectToPassToReact = {
+		'initialCount': 42,
+		'someString': '"Quotes" work, \\backslashes\\ work, <tags> work.'
+	}
+	# We will pass the object via Django's rendering context
+	# This context should be a dictionary.
+	# You can use whatever key you want; you'll get data from the context by using the key in the HTML template.
+	context = { 'data': objectToPassToReact }
+	return render(request, 'scrub_hub_frontend/index.html', context)

--- a/scrub_hub_vite/src/App.tsx
+++ b/scrub_hub_vite/src/App.tsx
@@ -3,8 +3,12 @@ import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
 import './App.css'
 
-function App() {
-	const [count, setCount] = useState(0)
+export type AppProps = {
+	initialCount: number,
+	someString?: string,
+};
+export function App({ initialCount = 0, someString }: AppProps) {
+	const [count, setCount] = useState(initialCount)
 
 	return <>
 		<div>
@@ -20,6 +24,7 @@ function App() {
 			<button onClick={() => setCount((count) => count + 1)}>
 				count is {count}
 			</button>
+			<p>Strings are escaped in the script tag, so they parse correctly: {someString}</p>
 			<p>
 				Edit <code>src/App.tsx</code> and save to test HMR
 			</p>

--- a/scrub_hub_vite/src/GetScriptData.ts
+++ b/scrub_hub_vite/src/GetScriptData.ts
@@ -1,0 +1,11 @@
+/**
+ * This method is meant to assist in getting data from the Django view.
+ * See the HTML template scrub_hub_frontend/index.html for what's required in there.
+ * @param scriptId The id of the HTML script tag.
+ */
+export default function GetScriptData(scriptId: string = '_DjangoData_'): { [key: string]: unknown } {
+	// We get the HTML document's script element and it's text content.
+	const rawData = document.getElementById(scriptId)?.textContent;
+	// Since the text content is a string we must parse it.
+	return JSON.parse(rawData ?? '{}');
+}

--- a/scrub_hub_vite/src/main.tsx
+++ b/scrub_hub_vite/src/main.tsx
@@ -2,11 +2,25 @@ import 'vite/modulepreload-polyfill';
 
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import App from './App.tsx'
+import { App, AppProps } from './App.tsx'
 import './index.css'
+import GetScriptData from './GetScriptData.ts';
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-	<React.StrictMode>
-		<App />
-	</React.StrictMode>,
-)
+// Vite's HMR apparently doesn't work super well with django-vite.
+// We check if the root has already been created. If so, we don't need to re-create or re-render here.
+// Oddly, serving directly through vite's dev server does not have this issue.
+const container: HTMLElement & { reactRoot?: ReactDOM.Root } = document.getElementById('root')!;
+if (!container.reactRoot) {
+	const root = container.reactRoot = ReactDOM.createRoot(container);
+	root.render(
+		<React.StrictMode>
+			{/*
+				Here we are using the results of GetDjangoData as a AppProps object.
+				There is nothing in this code or elsewhere that ensures it is actually a AppProps object!
+				Unfortunately, I haven't found anything that verifies the type automatically.
+				You should probably implement code to validate important props.
+			*/}
+			<App {...GetScriptData() as AppProps} />
+		</React.StrictMode>
+	)
+}


### PR DESCRIPTION
Some pages/components will need access to data that lives in Python. Data can be passed to components through Django's render context.
This is not applicable for all data that components need. Data loaded after the initial page load should be loaded through an API call, which isn't shown here.